### PR TITLE
APIReference/next.config.jsOptions 경로 rewrites 등 번역 완료

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
-# Nextjs-docs-Korean-translation
 
+# Nextjs-docs-Korean-translation
 ## Next.js 한글 문서
+
 
 본문서에서는 [Next.js Docs](https://nextjs.org/docs) 를 한글로 번역하는 프로젝트를 진행중입니다.
 
 번역에 참여하실 분은 해당 레포에서 참여해주세요
 
-기여와 관련된 내용은 [Contribution Guidelines](CONTRIBUTING.md)을 참고해주세요
+기여와 관련된 내용은  [Contribution Guidelines](CONTRIBUTING.md)을 참고해주세요
+
+
 
 <br>
+
 
 [![Since](https://img.shields.io/badge/since-2023.05.01-333333.svg?style=flat-square)](https://github.com/XionWCFM/)
 [![LICENSE](https://img.shields.io/dub/l/vibe-d.svg?style=flat-square)](https://github.com/XionWCFM/Nextjs-docs-Korean-translation)
@@ -19,17 +23,22 @@
 
 <br>
 
+
 # 컨트리뷰터 목록
 
 <br>
+
 
 <a href="https://github.com/XionWCFM/Nextjs-docs-Korean-translation/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=XionWCFM/Nextjs-docs-Korean-translation" />
 </a>
 
+
 <br>
 
 <br>
+
+
 
 <br>
 
@@ -40,10 +49,12 @@
 [joywhy](https://github.com/joywhy)
 감사합니다!
 
+
 # 문서 하이퍼링크
 
-# Getting Started
 
+
+# Getting Started
 [Installation](./nextjsdocs/GettingStarted/Installation.md)
 
 [React Essentials](./nextjsdocs/GettingStarted/React_Essentials.md)
@@ -53,6 +64,8 @@
 ---
 
 # API Reference
+
+
 
 ### Components
 
@@ -64,7 +77,9 @@
 
 [Scripts](./nextjsdocs/APIReference/Components/Script.md)
 
-### File Conventions
+
+
+### File Conventions 
 
 <details>
 <summary>Metadata</summary>
@@ -102,7 +117,6 @@
 <br>
 
 ### Functions
-
 [cookies](./nextjsdocs/APIReference/Functions/cookies.md)
 
 [draftMode](./nextjsdocs/APIReference/Functions/draftMode.md)
@@ -133,6 +147,7 @@
 
 [usePathname](./nextjsdocs/APIReference/Functions/usePathname.md)
 
+
 [useReportWebVitals](./nextjsdocs/APIReference/Functions/useReportWebVitals.md)
 
 [useRouter](./nextjsdocs/APIReference/Functions/useRouter.md)
@@ -145,8 +160,8 @@
 
 <br>
 
-### next.config.js Options
 
+### next.config.js Options
 [appDir](./nextjsdocs/APIReference/next.config.jsOptions/appDir.md)
 
 [assetPrefix](./nextjsdocs/APIReference/next.config.jsOptions/assetPrefix.md)
@@ -165,13 +180,18 @@
 
 [exportPathMap](./nextjsdocs/APIReference/next.config.jsOptions/exportPathMap.md)
 
+
 [generateBuildld](./nextjsdocs/APIReference/next.config.jsOptions/generateBuildld.md)
+
 
 [generateEtages](./nextjsdocs/APIReference/next.config.jsOptions/generateEtages.md)
 
+
 [headers](./nextjsdocs/APIReference/next.config.jsOptions/headers.md)
 
+
 [httpAgentOptions](./nextjsdocs/APIReference/next.config.jsOptions/httpAgentOptions.md)
+
 
 [images](./nextjsdocs/APIReference/next.config.jsOptions/images.md)
 
@@ -183,6 +203,7 @@
 
 [pageExtensions](./nextjsdocs/APIReference/next.config.jsOptions/pageExtensions.md)
 
+
 [poweredByHeader](./nextjsdocs/APIReference/next.config.jsOptions/poweredByHeader.md)
 
 [productionBrowserSourceMaps](./nextjsdocs/APIReference/next.config.jsOptions/productionBrowserSourceMaps.md)
@@ -193,9 +214,10 @@
 
 [rewrites](./nextjsdocs/APIReference/next.config.jsOptions/rewrites.md)
 
+
 [serverComponentsExternalPackages](./nextjsdocs/APIReference/next.config.jsOptions/serverComponentsExternalPackages.md)
 
-[Runtime Config](./nextjsdocs/APIReference/next.config.jsOptions/RuntimeConfig.md)
+[RuntimeConfig](./nextjsdocs/APIReference/next.config.jsOptions/RuntimeConfig.md)
 
 [trailingSlash](./nextjsdocs/APIReference/next.config.jsOptions/trailingSlash.md)
 
@@ -209,9 +231,12 @@
 
 [urllmports](./nextjsdocs/APIReference/next.config.jsOptions/urllmports.md)
 
+
 [webpack](./nextjsdocs/APIReference/next.config.jsOptions/webpack.md)
 
 [webVitalsAttribution](./nextjsdocs/APIReference/next.config.jsOptions/webVitalsAttribution.md)
+
+
 
 <br>
 
@@ -221,6 +246,8 @@
 
 [Next.jsCLI](./nextjsdocs/APIReference/Next.jsCLI.md)
 
+
+
 <br>
 
 ---
@@ -229,7 +256,10 @@
 
 <br>
 
+
+
 ### Routing
+
 
 [Routing](./nextjsdocs/BuildingYourApplication/Routing/Routing.md)
 
@@ -261,6 +291,7 @@
 
 ### Rendering
 
+
 [Static and Dynamic](./nextjsdocs/BuildingYourApplication/Rendering/Static_and_Dynamic.md)
 
 [Edge and Node.js Runtimes](./nextjsdocs/BuildingYourApplication/Rendering/Edge_and_Node.js_Runtimes.md)
@@ -268,6 +299,8 @@
 <br>
 
 ### Data Fetching
+
+
 
 [Fetching](./nextjsdocs/BuildingYourApplication/DataFetching/Fetching.md)
 
@@ -277,9 +310,12 @@
 
 [Server Actions](./nextjsdocs/BuildingYourApplication/DataFetching/Server_Actions.md)
 
+
 <br>
 
 ### Styling
+
+
 
 [CSS Modules](./nextjsdocs/BuildingYourApplication/Styling/CSS_Modules.md)
 
@@ -292,6 +328,7 @@
 <br>
 
 ### Optimizing
+
 
 [Images](./nextjsdocs/BuildingYourApplication/Optimizing/Images.md)
 
@@ -311,9 +348,12 @@
 
 [Instrumentation](./nextjsdocs/BuildingYourApplication/Optimizing/Instrumentation.md)
 
+
+
 <br>
 
 ### Configuring
+
 
 [TypeScript](./nextjsdocs/BuildingYourApplication/Configuring/TypeScript.md)
 
@@ -333,11 +373,17 @@
 
 ### Deploying
 
+
+
 [Static Exports](./nextjsdocs/BuildingYourApplication/Deploying/Static_Exports.md)
+
 
 <br>
 
+
 ### Upgrading
+
+
 
 [Upgrading](./nextjsdocs/BuildingYourApplication/Upgrading/Upgrading.md)
 
@@ -345,11 +391,15 @@
 
 [App Router Migration](./nextjsdocs/BuildingYourApplication/Upgrading/App_Router_Migration.md)
 
+
 <br>
+
 
 ---
 
 # Architecture
+
+
 
 [Accessibility](./nextjsdocs/Architecture/Accessibility.md)
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
-
 # Nextjs-docs-Korean-translation
-## Next.js 한글 문서
 
+## Next.js 한글 문서
 
 본문서에서는 [Next.js Docs](https://nextjs.org/docs) 를 한글로 번역하는 프로젝트를 진행중입니다.
 
 번역에 참여하실 분은 해당 레포에서 참여해주세요
 
-기여와 관련된 내용은  [Contribution Guidelines](CONTRIBUTING.md)을 참고해주세요
-
-
+기여와 관련된 내용은 [Contribution Guidelines](CONTRIBUTING.md)을 참고해주세요
 
 <br>
-
 
 [![Since](https://img.shields.io/badge/since-2023.05.01-333333.svg?style=flat-square)](https://github.com/XionWCFM/)
 [![LICENSE](https://img.shields.io/dub/l/vibe-d.svg?style=flat-square)](https://github.com/XionWCFM/Nextjs-docs-Korean-translation)
@@ -23,22 +19,17 @@
 
 <br>
 
-
 # 컨트리뷰터 목록
 
 <br>
-
 
 <a href="https://github.com/XionWCFM/Nextjs-docs-Korean-translation/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=XionWCFM/Nextjs-docs-Korean-translation" />
 </a>
 
-
 <br>
 
 <br>
-
-
 
 <br>
 
@@ -49,12 +40,10 @@
 [joywhy](https://github.com/joywhy)
 감사합니다!
 
-
 # 문서 하이퍼링크
 
-
-
 # Getting Started
+
 [Installation](./nextjsdocs/GettingStarted/Installation.md)
 
 [React Essentials](./nextjsdocs/GettingStarted/React_Essentials.md)
@@ -64,8 +53,6 @@
 ---
 
 # API Reference
-
-
 
 ### Components
 
@@ -77,9 +64,7 @@
 
 [Scripts](./nextjsdocs/APIReference/Components/Script.md)
 
-
-
-### File Conventions 
+### File Conventions
 
 <details>
 <summary>Metadata</summary>
@@ -117,6 +102,7 @@
 <br>
 
 ### Functions
+
 [cookies](./nextjsdocs/APIReference/Functions/cookies.md)
 
 [draftMode](./nextjsdocs/APIReference/Functions/draftMode.md)
@@ -147,7 +133,6 @@
 
 [usePathname](./nextjsdocs/APIReference/Functions/usePathname.md)
 
-
 [useReportWebVitals](./nextjsdocs/APIReference/Functions/useReportWebVitals.md)
 
 [useRouter](./nextjsdocs/APIReference/Functions/useRouter.md)
@@ -160,8 +145,8 @@
 
 <br>
 
-
 ### next.config.js Options
+
 [appDir](./nextjsdocs/APIReference/next.config.jsOptions/appDir.md)
 
 [assetPrefix](./nextjsdocs/APIReference/next.config.jsOptions/assetPrefix.md)
@@ -180,18 +165,13 @@
 
 [exportPathMap](./nextjsdocs/APIReference/next.config.jsOptions/exportPathMap.md)
 
-
 [generateBuildld](./nextjsdocs/APIReference/next.config.jsOptions/generateBuildld.md)
-
 
 [generateEtages](./nextjsdocs/APIReference/next.config.jsOptions/generateEtages.md)
 
-
 [headers](./nextjsdocs/APIReference/next.config.jsOptions/headers.md)
 
-
 [httpAgentOptions](./nextjsdocs/APIReference/next.config.jsOptions/httpAgentOptions.md)
-
 
 [images](./nextjsdocs/APIReference/next.config.jsOptions/images.md)
 
@@ -203,7 +183,6 @@
 
 [pageExtensions](./nextjsdocs/APIReference/next.config.jsOptions/pageExtensions.md)
 
-
 [poweredByHeader](./nextjsdocs/APIReference/next.config.jsOptions/poweredByHeader.md)
 
 [productionBrowserSourceMaps](./nextjsdocs/APIReference/next.config.jsOptions/productionBrowserSourceMaps.md)
@@ -214,10 +193,9 @@
 
 [rewrited](./nextjsdocs/APIReference/next.config.jsOptions/rewrited.md)
 
-
 [serverComponentsExternalPackages](./nextjsdocs/APIReference/next.config.jsOptions/serverComponentsExternalPackages.md)
 
-[serverRuntimeConfig_and_publicRuntimeConfig](./nextjsdocs/APIReference/next.config.jsOptions/serverRuntimeConfig_and_publicRuntimeConfig.md)
+[Runtime Config](./nextjsdocs/APIReference/next.config.jsOptions/RuntimeConfig.md)
 
 [trailingSlash](./nextjsdocs/APIReference/next.config.jsOptions/trailingSlash.md)
 
@@ -231,12 +209,9 @@
 
 [urllmports](./nextjsdocs/APIReference/next.config.jsOptions/urllmports.md)
 
-
 [webpack](./nextjsdocs/APIReference/next.config.jsOptions/webpack.md)
 
 [webVitalsAttribution](./nextjsdocs/APIReference/next.config.jsOptions/webVitalsAttribution.md)
-
-
 
 <br>
 
@@ -246,8 +221,6 @@
 
 [Next.jsCLI](./nextjsdocs/APIReference/Next.jsCLI.md)
 
-
-
 <br>
 
 ---
@@ -256,10 +229,7 @@
 
 <br>
 
-
-
 ### Routing
-
 
 [Routing](./nextjsdocs/BuildingYourApplication/Routing/Routing.md)
 
@@ -291,7 +261,6 @@
 
 ### Rendering
 
-
 [Static and Dynamic](./nextjsdocs/BuildingYourApplication/Rendering/Static_and_Dynamic.md)
 
 [Edge and Node.js Runtimes](./nextjsdocs/BuildingYourApplication/Rendering/Edge_and_Node.js_Runtimes.md)
@@ -299,8 +268,6 @@
 <br>
 
 ### Data Fetching
-
-
 
 [Fetching](./nextjsdocs/BuildingYourApplication/DataFetching/Fetching.md)
 
@@ -310,12 +277,9 @@
 
 [Server Actions](./nextjsdocs/BuildingYourApplication/DataFetching/Server_Actions.md)
 
-
 <br>
 
 ### Styling
-
-
 
 [CSS Modules](./nextjsdocs/BuildingYourApplication/Styling/CSS_Modules.md)
 
@@ -328,7 +292,6 @@
 <br>
 
 ### Optimizing
-
 
 [Images](./nextjsdocs/BuildingYourApplication/Optimizing/Images.md)
 
@@ -348,12 +311,9 @@
 
 [Instrumentation](./nextjsdocs/BuildingYourApplication/Optimizing/Instrumentation.md)
 
-
-
 <br>
 
 ### Configuring
-
 
 [TypeScript](./nextjsdocs/BuildingYourApplication/Configuring/TypeScript.md)
 
@@ -373,17 +333,11 @@
 
 ### Deploying
 
-
-
 [Static Exports](./nextjsdocs/BuildingYourApplication/Deploying/Static_Exports.md)
-
 
 <br>
 
-
 ### Upgrading
-
-
 
 [Upgrading](./nextjsdocs/BuildingYourApplication/Upgrading/Upgrading.md)
 
@@ -391,15 +345,11 @@
 
 [App Router Migration](./nextjsdocs/BuildingYourApplication/Upgrading/App_Router_Migration.md)
 
-
 <br>
-
 
 ---
 
 # Architecture
-
-
 
 [Accessibility](./nextjsdocs/Architecture/Accessibility.md)
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@
 
 [redirects](./nextjsdocs/APIReference/next.config.jsOptions/redirects.md)
 
-[rewrited](./nextjsdocs/APIReference/next.config.jsOptions/rewrited.md)
+[rewrites](./nextjsdocs/APIReference/next.config.jsOptions/rewrites.md)
 
 [serverComponentsExternalPackages](./nextjsdocs/APIReference/next.config.jsOptions/serverComponentsExternalPackages.md)
 

--- a/nextjsdocs/APIReference/Functions/useReportWebVitals.md
+++ b/nextjsdocs/APIReference/Functions/useReportWebVitals.md
@@ -1,0 +1,141 @@
+# useReportWebVitals
+
+공식 문서 : [https://nextjs.org/docs/app/api-reference/functions/use-report-web-vitals](https://nextjs.org/docs/app/api-reference/functions/use-report-web-vitals)
+
+`useReportWebVitals` 훅을 사용하여 [Core Web Vitals](https://web.dev/vitals/)를 보고할 수 있으며, 다른 분석 서비스와 함께 사용할 수 있습니다.
+
+```jsx
+// app/_components/web-vitals.js
+
+"use client";
+
+import { useReportWebVitals } from "next/web-vitals";
+
+export function WebVitals() {
+  useReportWebVitals((metric) => {
+    console.log(metric);
+  });
+}
+```
+
+```jsx
+// app/layout.js
+
+import { WebVitals } from "./_components/web-vitals";
+
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>
+        <WebVitals />
+        {children}
+      </body>
+    </html>
+  );
+}
+```
+
+> `useReportWebVitals` 훅은 `"use client"` 지시문을 필요로 하기 때문에, 성능 면에서 가장 우수한 접근 방식은 루트 레이아웃이 가져오는 별도의 컴포넌트를 생성하는 것입니다. 이렇게 하면 클라이언트 영역이 오로지 `WebVitals` 컴포넌트에 국한됩니다.
+
+<br><hr><br>
+
+## useReportWebVitals
+
+훅의 인자로 전달되는 `metric` 객체는 다수의 속성으로 구성됩니다.
+
+- `id` : 현재 페이지 로드의 맥락에서 해당 metric에 대한 고유 식별자
+
+- `name` : 성능 metric의 이름입니다. 웹 애플리케이션에 특정한 [Web Vitals](./useReportWebVitals#web-vitals)(TTFB, FCP, LCP, FID, CLS)의 이름이 가능한 값으로 포함됩니다.
+
+- `delta` : metric의 현재 값과 이전 값의 차이입니다. 값은 일반적으로 밀리초 단위이며, 시간에 따른 metric 값의 변화를 나타냅니다.
+
+- `entries` : metric과 관련된 [성능 항목](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry)의 배열입니다. 이 항목들은 metric과 관련된 성능 이벤트에 대한 자세한 정보를 제공합니다.
+
+- `navigationType` : metric의 수집을 발생시킨 [navigation 유형](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type)을 나타냅니다. `"navigate"`, `"reload"`, `"back_forward"`, `"prerender"`와 같은 값을 사용할 수 있습니다.
+
+- `rating` : metric 값의 정성적인 등급으로, 성능에 대한 평가를 제공합니다. 가능한 값은 `"good"`, `"needs-improvement"`, `"poor"`입니다. 등급은 일반적으로 사전 정의된 임계값과 비교하여 metric 값이 수용 가능한지 또는 최적이 아닌지를 판단하여 결정됩니다.
+
+- `value` : 성능 항목의 실제 값 또는 기간으로, 일반적으로 밀리초 단위입니다. 이 값은 metric으로 추적되는 성능 측면의 양적인 측정 값을 제공합니다. 값의 출처는 측정되는 특정 metric에 따라 다를 수 있으며, 다양한 [Performance API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API)에서 가져올 수 있습니다.
+
+<br><hr><br>
+
+## Web Vitals
+
+[Web Vitals](https://web.dev/vitals/)는 웹 페이지의 사용자 경험을 포착하기 위한 유용한 metric의 집합입니다. 다음과 같은 Web Vital이 모두 포함되어 있습니다.
+
+- [Time to First Byte](https://developer.mozilla.org/en-US/docs/Glossary/Time_to_first_byte) (TTFB)
+- [First Contentful Paint](https://developer.mozilla.org/en-US/docs/Glossary/First_contentful_paint) (FCP)
+- [Largest Contentful Paint](https://web.dev/lcp/) (LCP)
+- [First Input Delay](https://web.dev/fid/) (FID)
+- [Cumulative Layout Shift](https://web.dev/cls/) (CLS)
+- [Interaction to Next Paint](https://web.dev/inp/) (INP)
+
+`name` 속성을 사용하여 이러한 metric의 모든 결과를 처리할 수 있습니다.
+
+```tsx
+// app/components/web-vitals.tsx
+
+"use client";
+
+import { useReportWebVitals } from "next/web-vitals";
+
+export function WebVitals() {
+  useReportWebVitals((metric) => {
+    switch (metric.name) {
+      case "FCP": {
+        // FCP 결과를 처리합니다.
+      }
+      case "LCP": {
+        // LCP 결과를 처리합니다.
+      }
+      // ...
+    }
+  });
+}
+```
+
+<br><hr><br>
+
+## Vercel에서의 사용법
+
+[Vercel Speed Insights](https://vercel.com/docs/concepts/speed-insights)는 Vercel 배포에서 자동으로 구성되며, `useReportWebVitals`를 사용하지 않아도 됩니다. 이 훅은 로컬에서 개발하는 경우 또는 다른 분석 서비스를 이용하는 경우에 유용합니다.
+
+<br><hr><br>
+
+## 외부 시스템으로 결과 전송하기
+
+사용자의 실제 성능을 측정하고 추적하기 위해 결과를 원하는 엔드포인트로 전송할 수 있습니다.
+
+예시:
+
+```jsx
+useReportWebVitals((metric) => {
+  const body = JSON.stringify(metric);
+  const url = "https://example.com/analytics";
+
+  // 가능한 경우 `navigator.sendBeacon()`을 사용하고, 그렇지 않은 경우 `fetch()`를 사용합니다.
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(url, body);
+  } else {
+    fetch(url, { body, method: "POST", keepalive: true });
+  }
+});
+```
+
+> Note : Google Analytics를 사용하는 경우, id 값을 사용하여 수동으로 metric 분포를 구성할 수 있습니다(백분위수 계산 등).
+
+```jsx
+useReportWebVitals((metric) => {
+  // Google Analytics를 초기화한 경우, 다음 예제와 같이 `window.gtag`를 사용하세요.
+  // https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics/pages/_app.js
+  window.gtag("event", metric.name, {
+    value: Math.round(
+      metric.name === "CLS" ? metric.value * 1000 : metric.value
+    ), // value는 반드시 정수여야 합니다.
+    event_label: metric.id, // 현재 페이지 로드에서 고유한 id
+    non_interaction: true, // 이탈률(Bounce Rate)에 영향을 주지 않도록 합니다.
+  });
+});
+```
+
+[Google Analytics로 결과를 전송하는 방법에 대해 자세히 알아봅니다.](https://github.com/GoogleChrome/web-vitals#send-the-results-to-google-analytics)

--- a/nextjsdocs/APIReference/next.config.jsOptions/RuntimeConfig.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/RuntimeConfig.md
@@ -26,7 +26,7 @@ module.exports = {
 
 클라이언트 및 서버 측 코드 모두에서 접근 가능한 것은 `publicRuntimeConfig`의 하위에 위치시킵니다.
 
-> `publicRuntimeConfig`에 의존하는 페이지는 **반드시** `getInitialProps` 또는 `getServerSideProps`를 사용하거나, 애플리케이션에서 getInitialProps를 사용하는 [사용자 지정 앱](https://nextjs.org/docs/pages/building-your-application/routing/custom-app)을 가져야만 [자동 정적 최적화](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)에서 제외될 수 있습니다. 런타임 구성은 서버 측 렌더링되지 않은 페이지(또는 페이지의 구성 요소)에서는 사용할 수 없습니다.
+> `publicRuntimeConfig`에 의존하는 페이지는 **반드시** `getInitialProps` 또는 `getServerSideProps`를 사용하거나, 애플리케이션에서 `getInitialProps`를 사용하는 [사용자 지정 앱](https://nextjs.org/docs/pages/building-your-application/routing/custom-app)을 가져야만 [자동 정적 최적화](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)에서 제외될 수 있습니다. 런타임 구성은 서버 측 렌더링되지 않은 페이지(또는 페이지의 구성 요소)에서는 사용할 수 없습니다.
 
 앱에서 런타임 구성에 접근하려면 다음과 같이 `next/config`를 사용합니다.
 

--- a/nextjsdocs/APIReference/next.config.jsOptions/RuntimeConfig.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/RuntimeConfig.md
@@ -1,0 +1,57 @@
+# 런타임 구성
+
+공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/runtime-configuration](https://nextjs.org/docs/app/api-reference/next-config-js/runtime-configuration)
+
+> Note : 이 기능은 레거시로 간주되며, [자동 정적 최적화(Automatic Static Optimization)](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization), [출력 파일 추적(Output File Tracing)](https://nextjs.org/docs/pages/api-reference/next-config-js/output#automatically-copying-traced-files), 또는 [React 서버 컴포넌트](../../GettingStarted/React_Essentials.md#server-components)와 함께 작동하지 않습니다. 초기화 오버헤드를 피하기 위해 [환경 변수](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables)를 사용하십시오.
+
+앱에 런타임 구성을 추가하려면 `next.config.js` 파일을 열고 `publicRuntimeConfig`와 `serverRuntimeConfig`를 추가합니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  serverRuntimeConfig: {
+    // 서버 측에서만 사용 가능합니다.
+    mySecret: "secret",
+    secondSecret: process.env.SECOND_SECRET, // 환경 변수를 통해 전달합니다.
+  },
+  publicRuntimeConfig: {
+    // 서버 측, 클라이언트 측 모두 사용 가능합니다.
+    staticFolder: "/static",
+  },
+};
+```
+
+서버 전용 런타임 구성은 `serverRuntimeConfig`의 하위에 위치시킵니다.
+
+클라이언트 및 서버 측 코드 모두에서 접근 가능한 것은 `publicRuntimeConfig`의 하위에 위치시킵니다.
+
+> `publicRuntimeConfig`에 의존하는 페이지는 **반드시** `getInitialProps` 또는 `getServerSideProps`를 사용하거나, 애플리케이션에서 getInitialProps를 사용하는 [사용자 지정 앱](https://nextjs.org/docs/pages/building-your-application/routing/custom-app)을 가져야만 [자동 정적 최적화](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)에서 제외될 수 있습니다. 런타임 구성은 서버 측 렌더링되지 않은 페이지(또는 페이지의 구성 요소)에서는 사용할 수 없습니다.
+
+앱에서 런타임 구성에 접근하려면 다음과 같이 `next/config`를 사용합니다.
+
+```jsx
+import getConfig from "next/config";
+import Image from "next/image";
+
+// serverRuntimeConfig, publicRuntimeConfig만 변수로 저장합니다.
+const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
+// 서버 측에서만 사용 가능합니다.
+console.log(serverRuntimeConfig.mySecret);
+// 서버 측, 클라이언트 측 모두 사용 가능합니다.
+console.log(publicRuntimeConfig.staticFolder);
+
+function MyImage() {
+  return (
+    <div>
+      <Image
+        src={`${publicRuntimeConfig.staticFolder}/logo.png`}
+        alt="logo"
+        layout="fill"
+      />
+    </div>
+  );
+}
+
+export default MyImage;
+```

--- a/nextjsdocs/APIReference/next.config.jsOptions/reactStrictMode.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/reactStrictMode.md
@@ -1,0 +1,19 @@
+# reactStrictMode
+
+공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/reactStrictMode](https://nextjs.org/docs/app/api-reference/next-config-js/reactStrictMode)
+
+> 권장됨 : 향후의 React에 대비하기 위해 Next.js 애플리케이션에서 Strict Mode를 활성화하는 것을 강력히 권장합니다.
+
+React의 Strict Mode는 애플리케이션에서 잠재적인 문제를 강조하기 위한 개발 모드 전용 기능입니다. 이는 안전하지 않은 생명 주기(Lifecycles), 레거시 API 사용 및 여러 다른 기능을 식별하는 데 도움이 됩니다.
+
+Next.js 런타임은 Strict Mode를 준수합니다. Strict Mode를 사용하려면 next.config.js에서 다음 옵션을 구성하십시오.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  reactStrictMode: true,
+};
+```
+
+만약 애플리케이션 전체에 Strict Mode를 사용할 준비가 되지 않았다면, 그래도 괜찮습니다! `<React.StrictMode>`를 사용하여 페이지별로 점진적으로 마이그레이션할 수 있습니다.

--- a/nextjsdocs/APIReference/next.config.jsOptions/redirects.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/redirects.md
@@ -1,0 +1,334 @@
+# redirects
+
+공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/redirects](https://nextjs.org/docs/app/api-reference/next-config-js/redirects)
+
+redirects는 들어오는 요청 경로를 다른 대상 경로로 리다이렉션할 수 있도록 해줍니다.
+
+redirects를 사용하기 위해 `next.config.js` 파일에서 `redirects` 키를 사용할 수 있습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: "/about",
+        destination: "/",
+        permanent: true,
+      },
+    ];
+  },
+};
+```
+
+`redirects`는 배열을 반환하는 비동기 함수입니다. 반환되는 배열은 `source`, `destination`, `permanent` 속성을 가진 객체들을 포함해야 합니다.
+
+- `source`는 들어오는 요청 경로 패턴입니다.
+- `destination`은 라우팅하고자 하는 경로입니다.
+- `permanent` : `true` 혹은 `false` - `true`로 설정하면 308 상태 코드가 사용되며, 이는 클라이언트 및 검색 엔진에게 리다이렉션을 영구적으로 캐시하도록 지시합니다. 반대로 `false`로 설정하면 307 상태 코드가 사용되며, 이는 일시적인 리다이렉션을 나타내며 캐시되지 않습니다.
+
+> **Next.js는 왜 307, 308을 사용하나요?** 기존에는 일시적인 리다이렉션을 나타내기 위해 302가 사용되고 영구적인 리다이렉션을 나타내기 위해 301이 사용되었지만, 많은 브라우저에서 리다이렉션의 요청 방법을 `GET`으로 변경했습니다. 예를 들어, 브라우저가 `POST /v1/users`에 대한 요청을 만들고 위치 `/v2/users`로 `302` 상태 코드가 반환되었다면, 예상되는 `POST /v2/users` 대신 `GET /v2/users`와 같은 후속 요청이 발생할 수 있습니다. Next.js는 307 임시 리다이렉션 및 308 영구 리다이렉션 상태 코드를 사용하여 요청 방법을 명시적으로 보존합니다.
+
+- `basePath` : `false` 또는 `undefined` - false인 경우 일치할 때 `basePath`는 포함되지 않으며, 외부 redirects에만 사용할 수 있습니다.
+- `locale` : `false` 또는 `undefined` - 일치할 때 locale을 포함하지 않아야 하는지 여부입니다.
+- `has`는 `type`, `key`, `value` 속성을 가진 [has 객체](./redirects.md#header-cookie-and-query-matching)의 배열입니다.
+- `missing`은 `type`, `key`, `value` 속성을 가진 [missing 객체](./redirects.md#header-cookie-and-query-matching)의 배열입니다.
+
+리다이렉트는 페이지와 `/public` 파일을 포함한 파일 시스템보다 먼저 확인됩니다.
+
+리다이렉트는 클라이언트 측 라우팅(`Link`, `router.push`)에는 적용되지 않습니다. 단, [미들웨어](../../BuildingYourApplication/Routing/Middleware.md)가 존재하고 경로와 일치하는 경우에는 적용됩니다.
+
+리다이렉트가 적용되면 요청에 제공된 쿼리 값이 리다이렉트 대상으로 전달됩니다. 예를 들어, 다음과 같은 리다이렉트 구성을 살펴보세요.
+
+```jsx
+{
+  source: '/old-blog/:path*',
+  destination: '/blog/:path*',
+  permanent: false
+}
+```
+
+`/old-blog/post-1?hello=world`가 요청되면 클라이언트는 `/blog/post-1?hello=world`로 리다이렉트됩니다.
+
+<br><hr><br>
+
+## 경로 매칭
+
+경로 매칭이 허용됩니다. 예를 들어, `/old-blog/:slug`는 `/old-blog/hello-world`와 일치합니다(중첩된 경로는 허용되지 않습니다).
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: "/old-blog/:slug",
+        destination: "/news/:slug", // 일치하는 매개변수는 destination에서 사용할 수 있습니다.
+        permanent: true,
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+### 와일드카드 경로 매칭
+
+와일드카드 경로를 일치시키려면 매개변수 뒤에 `*`을 사용할 수 있습니다. 예를 들어, `/blog/:slug*`는 `/blog/a/b/c/d/hello-world`와 일치합니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: "/blog/:slug*",
+        destination: "/news/:slug*", // 일치하는 매개변수는 destination에서 사용할 수 있습니다.
+        permanent: true,
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+### 정규 표현식 경로 매칭
+
+정규 표현식 경로를 일치시키려면 매개변수 뒤에 정규식을 괄호로 감쌉니다. 예를 들어, `/post/:slug(\d{1,})`는 `/post/123`과 일치하지만 `/post/abc`와는 일치하지 않습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: "/post/:slug(\\d{1,})",
+        destination: "/news/:slug", // 일치하는 매개변수는 destination에서 사용할 수 있습니다.
+        permanent: false,
+      },
+    ];
+  },
+};
+```
+
+다음 문자들 `(`, `)`, `{`, `}`, `:`, `*`, `+`, `?`는 정규 표현식 경로 일치에 사용되므로 `source`에서 특수한 값으로 사용되지 않을 때에는 그 앞에 `\\`를 추가하여 이스케이프(escape)해야 합니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async redirects() {
+    return [
+      {
+        // '/english(default)/something'이 요청되었을 때 일치합니다.
+        source: "/english\\(default\\)/:slug",
+        destination: "/en-us/:slug",
+        permanent: false,
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+## 헤더, 쿠키, 쿼리 매칭
+
+헤더, 쿠키 또는 쿼리 값이 `has` 필드와 일치하거나 `missing` 필드와 일치하지 않을 때에만 리다이렉트 되도록 설정할 수 있습니다. `source`와 모든 `has` 아이템이 일치하고 모든 `missing` 아이템이 일치하지 않아야 리다이렉트가 적용됩니다.
+
+`has`와 `missing` 아이템은 다음과 같은 필드를 가질 수 있습니다.
+
+- `type` : `String` - 반드시 `header`, `cookie`, `host`, 또는 `query` 중 하나여야 합니다.
+- `key` : `String` - 일치 여부를 확인하기 위해 선택한 타입의 키입니다.
+- `value` : `String` 또는 `undefined` - 확인할 값입니다. undefined인 경우 어떤 값이든 일치합니다. 정규 표현식 형식의 문자열을 사용하여 값의 특정 부분을 포착할 수도 있습니다. 예를 들어, 값으로 `first-(?<paramName>.*)`을 사용하면 `first-second`와 일치하며, destination에서 `:paramName`과 함께 `second`를 사용할 수 있습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async redirects() {
+    return [
+      // 헤더에 'x-redirect-me'가 있다면 redirect가 적용됩니다.
+      {
+        source: "/:path((?!another-page$).*)",
+        has: [
+          {
+            type: "header",
+            key: "x-redirect-me",
+          },
+        ],
+        permanent: false,
+        destination: "/another-page",
+      },
+      // 헤더에 'x-do-not-redirect'가 있다면 redirect가 적용되지 않습니다.
+      {
+        source: "/:path((?!another-page$).*)",
+        missing: [
+          {
+            type: "header",
+            key: "x-do-not-redirect",
+          },
+        ],
+        permanent: false,
+        destination: "/another-page",
+      },
+      // source, 쿼리, 쿠키가 일치하면 redirect가 적용됩니다.
+      {
+        source: "/specific/:path*",
+        has: [
+          {
+            type: "query",
+            key: "page",
+            // page 값은 명명된 캡처 그룹 (예: (?<page>home))을 사용하지 않고
+            // value가 제공되므로 destination에서 사용할 수 없습니다.
+            value: "home",
+          },
+          {
+            type: "cookie",
+            key: "authorized",
+            value: "true",
+          },
+        ],
+        permanent: false,
+        destination: "/another/:path*",
+      },
+      // 헤더에 `x-authorized`가 있고 일치하는 값을 포함하고 있다면 redirect가 적용됩니다.
+      {
+        source: "/",
+        has: [
+          {
+            type: "header",
+            key: "x-authorized",
+            value: "(?<authorized>yes|true)",
+          },
+        ],
+        permanent: false,
+        destination: "/home?authorized=:authorized",
+      },
+      // host가 `example.com`이면 redirect가 적용됩니다.
+      {
+        source: "/:path((?!another-page$).*)",
+        has: [
+          {
+            type: "host",
+            value: "example.com",
+          },
+        ],
+        permanent: false,
+        destination: "/another-page",
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+### basePath support를 활용한 redirects
+
+[basePath 지원](./basePath.md)을 활용하여 redirects와 함께 사용할 때, redirect에 `basePath: false`를 추가하지 않는 한 `source`와 `destination`에 자동으로 `basePath`로 접두어가 붙습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  basePath: "/docs",
+
+  async redirects() {
+    return [
+      {
+        source: "/with-basePath", // 자동으로 /docs/with-basePath 로 변환됩니다.
+        destination: "/another", /// 자동으로 /docs/another 로 변환됩니다.
+        permanent: false,
+      },
+      {
+        // basePath: false 설정으로 인해 /docs가 추가되지 않습니다.
+        source: "/without-basePath",
+        destination: "https://example.com",
+        basePath: false,
+        permanent: false,
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+### i18n support를 활용한 redirects
+
+[`i18n` 지원](https://nextjs.org/docs/pages/building-your-application/routing/internationalization)을 활용하여 redirects와 함께 사용할 때, redirect에 `locale: false`를 추가하지 않는 한 구성된 `locales`를 처리하기 위해 `source`와 `destination`에 자동으로 접두어가 붙습니다. `locale: false`를 사용하는 경우 `source`와 `destination`에 locale을 접두어로 추가해야 올바르게 일치합니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  i18n: {
+    locales: ['en', 'fr', 'de'],
+    defaultLocale: 'en',
+  },
+
+  async redirects() {
+    return [
+      {
+        source: '/with-locale', // 자동으로 모든 locale을 처리합니다.
+        destination: '/another', // 자동으로 locale을 전달합니다.
+        permanent: false,
+      },
+      {
+        // locale: false가 설정되어 있기 때문에 자동으로 locale을 처리하지 않습니다.
+        source: '/nl/with-locale-manual',
+        destination: '/nl/another',
+        locale: false,
+        permanent: false,
+      },
+      {
+        // 'en'이 defaultLocale이므로 '/'와 일치합니다.
+        source: '/en',
+        destination: '/en/another',
+        locale: false,
+        permanent: false,
+      },
+      // locale: false가 설정되어 있어도 모든 locale과 일치시킬 수 있습니다.
+      {
+        source: '/:locale/page',
+        destination: '/en/newpage',
+        permanent: false,
+        locale: false,
+      }
+      {
+        // 이는 /(en|fr|de)/(.*)로 변환되므로 최상위 레벨과 일치하지 않을 것입니다.
+        // `/` 또는 `/fr`과 같은 경로는 /:path*와 일치할 것입니다.
+        source: '/(.*)',
+        destination: '/another',
+        permanent: false,
+      },
+    ]
+  },
+}
+```
+
+일부 특수한 경우에 오래된 HTTP 클라이언트가 올바른 리다이렉션을 수행하려면 사용자 정의 상태 코드를 지정해야 할 수 있습니다. 이러한 경우에는 `permanent` 속성 대신 `statusCode` 속성을 사용할 수 있습니다. 하지만 statusCode와 permanent를 함께 사용할 수는 없습니다. IE11 호환성을 보장하기 위해 308 상태 코드에 대해 `Refresh` 헤더가 자동으로 추가됩니다.
+
+<br><hr><br>
+
+## 기타 Redirects
+
+- [API Routes](https://nextjs.org/docs/pages/api-reference/functions/next-server) 내에서는 `res.redirect()`를 사용할 수 있습니다.
+- [`getStaticProps`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-props) 및 [`getServerSideProps`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props) 내에서는 요청 시점에 특정 페이지로 리다이렉션할 수 있습니다.
+
+<br><hr><br>
+
+## 버전 히스토리
+
+| Version   | Changes          |
+| --------- | ---------------- |
+| `v13.3.0` | `missing` 추가   |
+| `v10.2.0` | `has` 추가       |
+| `v9.5.0`  | `redirects` 추가 |

--- a/nextjsdocs/APIReference/next.config.jsOptions/rewrites.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/rewrites.md
@@ -1,0 +1,481 @@
+# rewrites
+
+공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/rewrites](https://nextjs.org/docs/app/api-reference/next-config-js/rewrites)
+
+rewrites는 들어오는 요청 경로를 다른 대상 경로로 매핑할 수 있도록 해줍니다.
+
+rewrites는 URL 프록시 역할을 하며 대상 경로를 가리고, 사용자가 사이트에서 위치를 변경하지 않은 것처럼 보이게 합니다. 반면, redirects는 새로운 페이지로 경로를 변경하고 URL 변경을 보여줍니다.
+
+rewrites를 사용하기 위해 `next.config.js` 파일에서 `rewrites` 키를 사용할 수 있습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: "/about",
+        destination: "/",
+      },
+    ];
+  },
+};
+```
+
+rewrites는 클라이언트 측 라우팅에 적용되며, 위의 예시에서 `<Link href="/about">`은 rewrite가 적용됩니다.
+
+`rewrites`는 배열 또는 배열 객체(아래 참조)를 반환하는 비동기 함수입니다. 각 객체는 `source`와 `destination` 속성을 가집니다.
+
+- `source` : `String` - 들어오는 요청 경로 패턴입니다.
+- `destination` : `String` - 라우팅하고자 하는 경로입니다.
+- `basePath` : `false` 또는 `undefined` - false인 경우 일치할 때 basePath는 포함되지 않으며, 외부 rewrites에만 사용할 수 있습니다.
+- `locale` : `false` 또는 `undefined` - 일치할 때 locale을 포함하지 않아야 하는지 여부입니다.
+- `has`는 `type`, `key`, `value` 속성을 가진 [has 객체](rewrites.md#header-cookie-and-query-matching)의 배열입니다.
+- `missing`은 `type`, `key`, `value` 속성을 가진 [missing 객체](rewrites.md#header-cookie-and-query-matching)의 배열입니다.
+
+`rewrites` 함수가 배열을 반환하는 경우, 파일 시스템(페이지 및 `/public` 파일)을 확인한 후 동적 라우트 이전에 `rewrites`가 적용됩니다. `rewrites` 함수가 특정 형태의 배열 객체를 반환하는 경우, Next.js의 `v10.1`부터 이 동작을 변경하고 더 정밀하게 제어할 수 있습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return {
+      beforeFiles: [
+        // headers/redirects 이후에 확인되며
+        // _next/public 파일을 포함한 모든 파일 이전에 확인됩니다.
+        // 페이지 파일을 덮어쓸 수 있습니다.
+        {
+          source: "/some-page",
+          destination: "/somewhere-else",
+          has: [{ type: "query", key: "overrideMe" }],
+        },
+      ],
+      afterFiles: [
+        // pages/public 파일 확인 이후에,
+        // dynamic routes 이전에 확인됩니다.
+        {
+          source: "/non-existent",
+          destination: "/somewhere-else",
+        },
+      ],
+      fallback: [
+        // pages/public 파일과 dynamic routes 확인 이후에 확인됩니다.
+        {
+          source: "/:path*",
+          destination: `https://my-old-site.com/:path*`,
+        },
+      ],
+    };
+  },
+};
+```
+
+> Note : `beforeFiles`의 rewrites는 소스와 일치한 후에 파일 시스템/동적 라우트를 즉시 확인하지 않고 모든 `beforeFiles`가 확인될 때까지 계속 진행됩니다.
+
+Next.js에서 라우트가 확인되는 순서는 다음과 같습니다.
+
+1. [headers](https://nextjs.org/docs/pages/api-reference/next-config-js/headers)가 확인되고 적용됩니다.
+2. [redirects](https://nextjs.org/docs/pages/api-reference/next-config-js/redirects)가 확인되고 적용됩니다.
+3. `beforeFiles` rewrites가 확인되고 적용됩니다.
+4. [public 디렉토리](https://nextjs.org/docs/pages/building-your-application/optimizing/static-assets)의 정적 파일, `\_next/static` 파일 및 비동적 페이지가 확인되고 제공됩니다.
+5. `afterFiles` rewrites가 확인되고 적용됩니다. 일치하는 rewrites가 있으면 각 일치 후 동적 라우트/정적 파일을 확인합니다.
+6. `fallback` rewrites가 확인되고 적용됩니다. 이러한 rewrites는 404 페이지 렌더링 전에 적용되며 동적 라우트/모든 정적 에셋이 확인된 후에 적용됩니다. `getStaticPaths`에서 [fallback: true 또는 'blocking'](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true)을 사용하는 경우, `next.config.js`에서 정의된 fallback `rewrites`가 실행되지 않습니다.
+
+<br><hr><br>
+
+## Rewrite 매개변수
+
+rewrite에서 매개변수를 사용할 때, `destination`에 매개변수가 사용되지 않은 경우 매개변수는 기본적으로 쿼리로 전달됩니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: "/old-about/:path*",
+        destination: "/about", // :path 매개변수가 사용되지 않았으므로 쿼리로 전달됩니다.
+      },
+    ];
+  },
+};
+```
+
+destination에 매개변수가 사용된 경우, 매개변수는 자동으로 쿼리로 전달되지 않습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: "/docs/:path*",
+        destination: "/:path*", // :path 매개변수가 사용되었으므로 쿼리로 자동으로 전달되지 않습니다.
+      },
+    ];
+  },
+};
+```
+
+`destination`에서 이미 매개변수가 사용된 경우, 대상에 직접 쿼리를 지정하여 매개변수를 수동으로 전달할 수 있습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: "/:first/:second",
+        destination: "/:first?second=:second",
+        // :first 매개변수가 사용되었기 때문에 :second 매개변수는 destination에
+        // 자동으로 쿼리로 전달되지 않지만 위의 예시처럼 수동으로 전달할 수 있습니다.
+      },
+    ];
+  },
+};
+```
+
+> Note : [자동 정적 최적화](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)에서 가져온 정적 페이지 또는 rewrites를 통해 [사전 렌더링](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-props)된 매개변수는 하이드레이션 후에 클라이언트에서 구문 분석(parse)되어 쿼리로 제공됩니다.
+
+<br><hr><br>
+
+## 경로 매칭
+
+경로 매칭이 허용됩니다. 예를 들어, `/blog/:slug`는 `/blog/hello-world`와 일치합니다(중첩된 경로는 허용되지 않습니다).
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: "/blog/:slug",
+        destination: "/news/:slug", // 일치하는 매개변수는 destination에서 사용할 수 있습니다.
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+### 와일드카드 경로 매칭
+
+와일드카드 경로를 일치시키려면 매개변수 뒤에 `*`을 사용할 수 있습니다. 예를 들어, `/blog/:slug*`는 `/blog/a/b/c/d/hello-world`와 일치합니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: "/blog/:slug*",
+        destination: "/news/:slug*", // 일치하는 매개변수는 destination에서 사용할 수 있습니다.
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+### 정규 표현식 경로 매칭
+
+정규 표현식 경로를 일치시키려면 매개변수 뒤에 정규식을 괄호로 감쌉니다. 예를 들어, `/blog/:slug(\d{1,})`는 `/blog/123`과 일치하지만 `/blog/abc`와는 일치하지 않습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: "/old-blog/:post(\\d{1,})",
+        destination: "/blog/:post", // 일치하는 매개변수는 destination에서 사용할 수 있습니다.
+      },
+    ];
+  },
+};
+```
+
+다음 문자들 `(`, `)`, `{`, `}`, `:`, `*`, `+`, `?`는 정규 표현식 경로 일치에 사용되므로 `source`에서 특수한 값으로 사용되지 않을 때에는 그 앞에 `\\`를 추가하여 이스케이프(escape)해야 합니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        // /english(default)/something이 요청되었을 때 일치합니다.
+        source: "/english\\(default\\)/:slug",
+        destination: "/en-us/:slug",
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+## 헤더, 쿠키, 쿼리 매칭
+
+헤더, 쿠키 또는 쿼리 값이 `has` 필드와 일치하거나 `missing` 필드와 일치하지 않을 때에만 rewrite가 일치하도록 설정할 수 있습니다. `source`와 모든 `has` 아이템이 일치하고 모든 `missing` 아이템이 일치하지 않아야 rewrite가 적용됩니다.
+
+`has`와 `missing` 아이템은 다음과 같은 필드를 가질 수 있습니다.
+
+- `type` : `String` - 반드시 `header`, `cookie`, `host`, 또는 `query` 중 하나여야 합니다.
+- `key` : `String` - 일치 여부를 확인하기 위해 선택한 타입의 키입니다.
+- `value` : `String` 또는 `undefined` - 확인할 값입니다. undefined인 경우 어떤 값이든 일치합니다. 정규 표현식 형식의 문자열을 사용하여 값의 특정 부분을 포착할 수도 있습니다. 예를 들어, 값으로 `first-(?<paramName>.*)`을 사용하면 `first-second`와 일치하며, destination에서 `:paramName`과 함께 `second`를 사용할 수 있습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return [
+      // 헤더에 'x-rewrite-me'가 있다면 rewrite가 적용됩니다.
+      {
+        source: "/:path*",
+        has: [
+          {
+            type: "header",
+            key: "x-rewrite-me",
+          },
+        ],
+        destination: "/another-page",
+      },
+      // 헤더에 'x-rewrite-me'가 없다면 rewrite가 적용됩니다.
+      {
+        source: "/:path*",
+        missing: [
+          {
+            type: "header",
+            key: "x-rewrite-me",
+          },
+        ],
+        destination: "/another-page",
+      },
+      // source, 쿼리, 쿠키가 일치하면 rewrite가 적용됩니다.
+      {
+        source: "/specific/:path*",
+        has: [
+          {
+            type: "query",
+            key: "page",
+            // page 값은 명명된 캡처 그룹 (예: (?<page>home))을 사용하지 않고
+            // value가 제공되므로 destination에서 사용할 수 없습니다.
+            value: "home",
+          },
+          {
+            type: "cookie",
+            key: "authorized",
+            value: "true",
+          },
+        ],
+        destination: "/:path*/home",
+      },
+      // 헤더에 `x-authorized`가 있고 일치하는 값을 포함하고 있다면 rewrite가 적용됩니다.
+      {
+        source: "/:path*",
+        has: [
+          {
+            type: "header",
+            key: "x-authorized",
+            value: "(?<authorized>yes|true)",
+          },
+        ],
+        destination: "/home?authorized=:authorized",
+      },
+      // host가 `example.com`이면 rewrite가 적용됩니다.
+      {
+        source: "/:path*",
+        has: [
+          {
+            type: "host",
+            value: "example.com",
+          },
+        ],
+        destination: "/another-page",
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+## 외부 URL로의 rewrite
+
+<details>
+<summary>예시</summary>
+
+- [점진적 Next.js 도입](https://github.com/vercel/next.js/tree/canary/examples/custom-routes-proxying)
+- [여러 Zone 사용](https://github.com/vercel/next.js/tree/canary/examples/custom-routes-proxying)
+</details>
+
+rewrites를 사용하면 외부 URL로 rewrite할 수 있습니다. 이는 Next.js를 점진적으로 도입하는 데 특히 유용합니다. 다음은 메인 앱의 `/blog` 경로를 외부 사이트로 redirection하는 rewrite 예시입니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: "/blog",
+        destination: "https://example.com/blog",
+      },
+      {
+        source: "/blog/:slug",
+        destination: "https://example.com/blog/:slug", // 일치하는 매개변수는 destination에서 사용할 수 있습니다.
+      },
+    ];
+  },
+};
+```
+
+`trailingSlash: true`를 사용하는 경우, `source` 매개변수에 후행 슬래시를 추가해야 합니다. destination 서버가 후행 슬래시를 기대하는 경우, `destination` 매개변수에도 이를 포함해야 합니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  trailingSlash: true,
+  async rewrites() {
+    return [
+      {
+        source: "/blog/",
+        destination: "https://example.com/blog/",
+      },
+      {
+        source: "/blog/:path*/",
+        destination: "https://example.com/blog/:path*/",
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+### Next.js의 점진적 도입
+
+Next.js에서는 모든 Next.js 경로를 확인한 후 기존 웹사이트로 프록시(proxy)하도록 fallback을 설정할 수도 있습니다.
+
+이러한 방식을 사용하면 Next.js로 추가 페이지를 마이그레이션할 때 rewrites 구성을 변경할 필요가 없습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  async rewrites() {
+    return {
+      fallback: [
+        {
+          source: "/:path*",
+          destination: `https://custom-routes-proxying-endpoint.vercel.app/:path*`,
+        },
+      ],
+    };
+  },
+};
+```
+
+<br><hr><br>
+
+### basePath support를 활용한 rewrites
+
+[basePath 지원](./basePath.md)을 활용하여 rewrites와 함께 사용할 때, rewrite에 `basePath: false`를 추가하지 않는 한 `source`와 `destination`에 자동으로 `basePath`로 접두어가 붙습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  basePath: "/docs",
+
+  async rewrites() {
+    return [
+      {
+        source: "/with-basePath", // 자동으로 /docs/with-basePath 로 변환됩니다.
+        destination: "/another", // 자동으로 /docs/another 로 변환됩니다.
+      },
+      {
+        // basePath: false 설정으로 인해
+        // /without-basePath에 /docs 가 추가되지 않습니다.
+        // Note : 내부 rewrites에 사용될 수 없습니다. 예 : `destination: '/another'`
+        source: "/without-basePath",
+        destination: "https://example.com",
+        basePath: false,
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+### i18n support를 활용한 rewrites
+
+[`i18n` 지원](https://nextjs.org/docs/pages/building-your-application/routing/internationalization)을 활용하여 rewrites와 함께 사용할 때, rewrite에 `locale: false`를 추가하지 않는 한 구성된 `locales`를 처리하기 위해 `source`와 `destination`에 자동으로 접두어가 붙습니다. `locale: false`를 사용하는 경우 `source`와 `destination`을 locale과 함께 접두어로 추가해야 올바르게 일치합니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  i18n: {
+    locales: ["en", "fr", "de"],
+    defaultLocale: "en",
+  },
+
+  async rewrites() {
+    return [
+      {
+        source: "/with-locale", // 자동으로 모든 locale을 처리합니다.
+        destination: "/another", // 자동으로 locale을 전달합니다.
+      },
+      {
+        // locale: false가 설정되어 있기 때문에 자동으로 locale을 처리하지 않습니다.
+        source: "/nl/with-locale-manual",
+        destination: "/nl/another",
+        locale: false,
+      },
+      {
+        // 'en'이 locale 기본값이기 때문에 이는 '/'와 일치합니다.
+        source: "/en",
+        destination: "/en/another",
+        locale: false,
+      },
+      {
+        // locale: false가 설정되어 있어도 모든 locale과 일치시킬 수 있습니다.
+        source: "/:locale/api-alias/:path*",
+        destination: "/api/:path*",
+        locale: false,
+      },
+      {
+        // 이는 /(en|fr|de)/(.*)로 변환되므로 최상위 레벨과 일치하지 않을 것입니다.
+        // `/` 또는 `/fr`과 같은 경로는 /:path*와 일치할 것입니다.
+        source: "/(.*)",
+        destination: "/another",
+      },
+    ];
+  },
+};
+```
+
+<br><hr><br>
+
+## 버전 히스토리
+
+| Version   | Changes        |
+| --------- | -------------- |
+| `v13.3.0` | `missing 추가` |
+| `v10.2.0` | `has 추가`     |
+| `v9.5.0`  | `Headers 추가` |

--- a/nextjsdocs/APIReference/next.config.jsOptions/rewrites.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/rewrites.md
@@ -409,7 +409,7 @@ module.exports = {
       },
       {
         // basePath: false 설정으로 인해
-        // /without-basePath에 /docs 가 추가되지 않습니다.
+        // /without-basePath에 /docs가 추가되지 않습니다.
         // Note : 내부 rewrites에 사용될 수 없습니다. 예 : `destination: '/another'`
         source: "/without-basePath",
         destination: "https://example.com",
@@ -424,7 +424,7 @@ module.exports = {
 
 ### i18n support를 활용한 rewrites
 
-[`i18n` 지원](https://nextjs.org/docs/pages/building-your-application/routing/internationalization)을 활용하여 rewrites와 함께 사용할 때, rewrite에 `locale: false`를 추가하지 않는 한 구성된 `locales`를 처리하기 위해 `source`와 `destination`에 자동으로 접두어가 붙습니다. `locale: false`를 사용하는 경우 `source`와 `destination`을 locale과 함께 접두어로 추가해야 올바르게 일치합니다.
+[`i18n` 지원](https://nextjs.org/docs/pages/building-your-application/routing/internationalization)을 활용하여 rewrites와 함께 사용할 때, rewrite에 `locale: false`를 추가하지 않는 한 구성된 `locales`를 처리하기 위해 `source`와 `destination`에 자동으로 접두어가 붙습니다. `locale: false`를 사용하는 경우 `source`와 `destination`에 locale을 접두어로 추가해야 올바르게 일치합니다.
 
 ```jsx
 // next.config.js
@@ -476,6 +476,6 @@ module.exports = {
 
 | Version   | Changes        |
 | --------- | -------------- |
-| `v13.3.0` | `missing 추가` |
-| `v10.2.0` | `has 추가`     |
-| `v9.5.0`  | `Headers 추가` |
+| `v13.3.0` | `missing` 추가 |
+| `v10.2.0` | `has` 추가     |
+| `v9.5.0`  | `Headers` 추가 |

--- a/nextjsdocs/APIReference/next.config.jsOptions/serverComponentsExternalPackages.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/serverComponentsExternalPackages.md
@@ -4,7 +4,7 @@
 
 [서버 컴포넌트](../../GettingStarted/React_Essentials.md#server-components) 및 [라우트 핸들러](../../BuildingYourApplication/Routing/Route_Handlers.md) 내에서 사용되는 종속성은 Next.js에 의해 자동으로 번들링됩니다.
 
-특정 종속성이 Node.js의 특정 기능을 사용하는 경우, 서버 컴포넌트 번들링에서 해당 종속성을 제외하고 네이티브 Node.js require를 사용할 수 있습니다.
+특정 종속성이 Node.js의 특정 기능을 사용하는 경우, 서버 컴포넌트 번들링에서 해당 종속성을 제외하고 네이티브 Node.js `require`를 사용할 수 있습니다.
 
 ```jsx
 // next.config.js
@@ -19,7 +19,7 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-Next.js는 현재 호환성 작업중이며, 자동으로 제외되는 [인기 있는 패키지의 짧은 목록](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/server-external-packages.json)을 포함합니다.
+Next.js는 현재 호환성 작업중이며 자동으로 제외되는 [인기 있는 패키지의 짧은 목록](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/server-external-packages.json)을 포함합니다.
 
 - `@prisma/client`
 - `@sentry/nextjs`

--- a/nextjsdocs/APIReference/next.config.jsOptions/serverComponentsExternalPackages.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/serverComponentsExternalPackages.md
@@ -1,0 +1,50 @@
+# 서버 컴포넌트 외부 패키지
+
+공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/serverComponentsExternalPackages](https://nextjs.org/docs/app/api-reference/next-config-js/serverComponentsExternalPackages)
+
+[서버 컴포넌트](../../GettingStarted/React_Essentials.md#server-components) 및 [라우트 핸들러](../../BuildingYourApplication/Routing/Route_Handlers.md) 내에서 사용되는 종속성은 Next.js에 의해 자동으로 번들링됩니다.
+
+특정 종속성이 Node.js의 특정 기능을 사용하는 경우, 서버 컴포넌트 번들링에서 해당 종속성을 제외하고 네이티브 Node.js require를 사용할 수 있습니다.
+
+```jsx
+// next.config.js
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverComponentsExternalPackages: ["@acme/ui"],
+  },
+};
+
+module.exports = nextConfig;
+```
+
+Next.js는 현재 호환성 작업중이며, 자동으로 제외되는 [인기 있는 패키지의 짧은 목록](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/server-external-packages.json)을 포함합니다.
+
+- `@prisma/client`
+- `@sentry/nextjs`
+- `@sentry/node`
+- `autoprefixer`
+- `aws-crt`
+- `bcrypt`
+- `cypress`
+- `eslint`
+- `express`
+- `firebase-admin`
+- `jest`
+- `lodash`
+- `mongodb`
+- `next-mdx-remote`
+- `next-seo`
+- `postcss`
+- `prettier`
+- `prisma`
+- `rimraf`
+- `sharp`
+- `shiki`
+- `sqlite3`
+- `tailwindcss`
+- `ts-node`
+- `typescript`
+- `vscode-oniguruma`
+- `webpack`

--- a/nextjsdocs/APIReference/next.config.jsOptions/trailingSlash.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/trailingSlash.md
@@ -2,7 +2,7 @@
 
 공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash](https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash)
 
-기본적으로 Next.js는 URL 끝에 슬래시가 있는 경우 슬래시가 없는 대응 URL로 리디렉션합니다. 예를 들어, `/about/`은 `/about`으로 리디렉션됩니다. 이 동작을 반대로 설정하여 슬래시가 없는 URL이 슬래시가 있는 대응 URL로 리디렉션되도록 구성할 수 있습니다.
+기본적으로 Next.js는 URL 끝에 슬래시가 있는 경우 슬래시가 없는 대응 URL로 리다이렉션합니다. 예를 들어, `/about/`은 `/about`으로 리다이렉션됩니다. 이 동작을 반대로 설정하여 슬래시가 없는 URL이 슬래시가 있는 대응 URL로 리다이렉션되도록 구성할 수 있습니다.
 
 `next.config.js` 파일을 열고 `trailingSlash` 구성을 추가합니다.
 
@@ -14,7 +14,7 @@ module.exports = {
 };
 ```
 
-이 옵션을 설정하면 `/about`과 같은 URL은 `/about/`로 리디렉션됩니다.
+이 옵션을 설정하면 `/about`과 같은 URL은 `/about/`로 리다이렉션됩니다.
 
 <br><hr><br>
 

--- a/nextjsdocs/APIReference/next.config.jsOptions/trailingSlash.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/trailingSlash.md
@@ -22,4 +22,4 @@ module.exports = {
 
 | Version  | Changes              |
 | -------- | -------------------- |
-| `v9.5.0` | `trailingSlash 추가` |
+| `v9.5.0` | `trailingSlash` 추가 |

--- a/nextjsdocs/APIReference/next.config.jsOptions/trailingSlash.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/trailingSlash.md
@@ -1,0 +1,25 @@
+# 후행 슬래시(trailingSlash)
+
+공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash](https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash)
+
+기본적으로 Next.js는 URL 끝에 슬래시가 있는 경우 슬래시가 없는 대응 URL로 리디렉션합니다. 예를 들어, `/about/`은 `/about`으로 리디렉션됩니다. 이 동작을 반대로 설정하여 슬래시가 없는 URL이 슬래시가 있는 대응 URL로 리디렉션되도록 구성할 수 있습니다.
+
+`next.config.js` 파일을 열고 `trailingSlash` 구성을 추가합니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  trailingSlash: true,
+};
+```
+
+이 옵션을 설정하면 `/about`과 같은 URL은 `/about/`로 리디렉션됩니다.
+
+<br><hr><br>
+
+## 버전 히스토리
+
+| Version  | Changes              |
+| -------- | -------------------- |
+| `v9.5.0` | `trailingSlash 추가` |

--- a/nextjsdocs/APIReference/next.config.jsOptions/trailingSlash.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/trailingSlash.md
@@ -1,4 +1,4 @@
-# 후행 슬래시(trailingSlash)
+# trailingSlash
 
 공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash](https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash)
 

--- a/nextjsdocs/APIReference/next.config.jsOptions/transpilePackages.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/transpilePackages.md
@@ -1,6 +1,6 @@
 # transpilePackages
 
-공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/transpilePackages](hhttps://nextjs.org/docs/app/api-reference/next-config-js/transpilePackages)
+공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/transpilePackages](https://nextjs.org/docs/app/api-reference/next-config-js/transpilePackages)
 
 Next.js는 자동으로 로컬 패키지(모노레포와 같은)나 외부 종속성(`node_modules`)에서 종속성을 트랜스파일하고 번들링할 수 있습니다. 이는 `next-transpile-modules` 패키지를 대체합니다.
 

--- a/nextjsdocs/APIReference/next.config.jsOptions/transpilePackages.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/transpilePackages.md
@@ -1,0 +1,24 @@
+# transpilePackages
+
+공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/transpilePackages](hhttps://nextjs.org/docs/app/api-reference/next-config-js/transpilePackages)
+
+Next.js는 자동으로 로컬 패키지(모노레포와 같은)나 외부 종속성(`node_modules`)에서 종속성을 트랜스파일하고 번들링할 수 있습니다. 이는 `next-transpile-modules` 패키지를 대체합니다.
+
+```jsx
+// next.config.js
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ["@acme/ui", "lodash-es"],
+};
+
+module.exports = nextConfig;
+```
+
+<br><hr><br>
+
+## 버전 히스토리
+
+| Version   | Changes                  |
+| --------- | ------------------------ |
+| `v13.0.0` | `transpilePackages 추가` |

--- a/nextjsdocs/APIReference/next.config.jsOptions/transpilePackages.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/transpilePackages.md
@@ -21,4 +21,4 @@ module.exports = nextConfig;
 
 | Version   | Changes                  |
 | --------- | ------------------------ |
-| `v13.0.0` | `transpilePackages 추가` |
+| `v13.0.0` | `transpilePackages` 추가 |

--- a/nextjsdocs/APIReference/next.config.jsOptions/webVitalsAttribution.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/webVitalsAttribution.md
@@ -1,0 +1,19 @@
+# webVitalsAttribution
+
+공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/webVitalsAttribution](https://nextjs.org/docs/app/api-reference/next-config-js/webVitalsAttribution)
+
+Web Vitals와 관련된 문제를 디버깅할 때 문제의 원인을 정확히 찾을 수 있다면 도움이 됩니다. 예를 들어, Cumulative Layout Shift (CLS)의 경우 단일 가장 큰 레이아웃 이동이 발생했을 때 첫 번째로 이동한 요소를 알고 싶을 수 있습니다. 또는 Largest Contentful Paint (LCP)의 경우, 페이지의 LCP에 해당하는 요소를 식별하고 싶을 수 있습니다. LCP 요소가 이미지인 경우 이미지 리소스의 URL을 알면 최적화해야 할 에셋(asset)을 찾는 데 도움이 될 수 있습니다.
+
+Web Vitals 점수에서 가장 큰 영향을 미치는 요소를 찾는 것, 즉 [속성(attribution)](https://github.com/GoogleChrome/web-vitals/blob/4ca38ae64b8d1e899028c692f94d4c56acfc996c/README.md#attribution)을 통해 [PerformanceEventTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming), [PerformanceNavigationTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming) 및 [PerformanceResourceTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming)과 같은 더 자세한 정보를 얻을 수 있습니다.
+
+Next.js에서는 기본적으로 속성(attribution)이 비활성화되어 있지만, `next.config.js` 파일에 다음과 같이 작성하여 각 지표(metric)별로 활성화할 수 있습니다.
+
+```jsx
+// next.config.js
+
+experimental: {
+  webVitalsAttribution: ["CLS", "LCP"];
+}
+```
+
+유효한 속성(attribution) 값은 [`NextWebVitalsMetric`](https://github.com/vercel/next.js/blob/442378d21dd56d6e769863eb8c2cb521a463a2e0/packages/next/shared/lib/utils.ts#L43) 유형에 지정된 모든 `web-vitals` 지표(metric)입니다.

--- a/nextjsdocs/APIReference/next.config.jsOptions/webpack.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/webpack.md
@@ -18,7 +18,7 @@
 - [@next/mdx](https://github.com/vercel/next.js/tree/canary/packages/next-mdx)
 - [@next/bundle-analyzer](https://github.com/vercel/next.js/tree/canary/packages/next-bundle-analyzer)
 
-webpack 사용을 확장하기 위해 next.config.js 내에서 config를 확장하는 함수를 다음과 같이 정의할 수 있습니다.
+`webpack` 사용을 확장하기 위해 `next.config.js` 내에서 config를 확장하는 함수를 다음과 같이 정의할 수 있습니다.
 
 ```jsx
 // next.config.js
@@ -34,7 +34,7 @@ module.exports = {
 };
 ```
 
-> webpack 함수는 서버와 클라이언트 각각에 대해 실행되어 총 두 번 실행됩니다. 이를 통해 isServer 속성을 사용하여 클라이언트와 서버 구성을 구별할 수 있습니다.
+> `webpack` 함수는 서버와 클라이언트 각각에 대해 실행되어 총 두 번 실행됩니다. 이를 통해 isServer 속성을 사용하여 클라이언트와 서버 구성을 구별할 수 있습니다.
 
 `webpack` 함수의 두 번째 인자는 다음과 같은 속성을 가진 객체입니다.
 

--- a/nextjsdocs/APIReference/next.config.jsOptions/webpack.md
+++ b/nextjsdocs/APIReference/next.config.jsOptions/webpack.md
@@ -1,0 +1,76 @@
+# Custom Webpack Config
+
+공식 문서 : [https://nextjs.org/docs/app/api-reference/next-config-js/webpack](https://nextjs.org/docs/app/api-reference/next-config-js/webpack)
+
+> Note : 웹팩 구성 변경은 semver에 포함되지 않으므로 위험 부담은 스스로 감수하여 진행하십시오.
+
+애플리케이션에 사용자 정의 웹팩 구성을 추가하기 전에, Next.js가 이미 사용 사례를 지원하는지 확인하십시오.
+
+- [CSS imports](https://nextjs.org/docs/pages/building-your-application/styling)
+- [CSS modules](https://nextjs.org/docs/pages/building-your-application/styling/css-modules)
+- [Sass/SCSS imports](https://nextjs.org/docs/pages/building-your-application/styling/sass)
+- [Sass/SCSS modules](https://nextjs.org/docs/pages/building-your-application/styling/sass)
+- [preact](https://github.com/vercel/next.js/tree/canary/examples/using-preact)
+- [바벨 구성 커스터마이징](https://nextjs.org/docs/pages/building-your-application/configuring/babel)
+
+자주 요청되는 몇 가지 기능은 플러그인으로 제공됩니다.
+
+- [@next/mdx](https://github.com/vercel/next.js/tree/canary/packages/next-mdx)
+- [@next/bundle-analyzer](https://github.com/vercel/next.js/tree/canary/packages/next-bundle-analyzer)
+
+webpack 사용을 확장하기 위해 next.config.js 내에서 config를 확장하는 함수를 다음과 같이 정의할 수 있습니다.
+
+```jsx
+// next.config.js
+
+module.exports = {
+  webpack: (
+    config,
+    { buildId, dev, isServer, defaultLoaders, nextRuntime, webpack }
+  ) => {
+    // 중요 : 수정된 구성을 반환합니다.
+    return config;
+  },
+};
+```
+
+> webpack 함수는 서버와 클라이언트 각각에 대해 실행되어 총 두 번 실행됩니다. 이를 통해 isServer 속성을 사용하여 클라이언트와 서버 구성을 구별할 수 있습니다.
+
+`webpack` 함수의 두 번째 인자는 다음과 같은 속성을 가진 객체입니다.
+
+- `buildId` : `String` - 빌드 ID로, 빌드 간의 고유한 식별자로 사용됩니다.
+- `dev` : `Boolean` - 개발 중인지 여부를 나타냅니다.
+- `isServer` : `Boolean` - 서버 측 컴파일인 경우 `true`이며, 클라이언트 측 컴파일인 경우 `false`입니다.
+- `nextRuntime` : `String | undefined` - 서버 측 컴파일의 대상 런타임입니다. `"edge"` 또는 `"nodejs"` 중 하나이며, 클라이언트 측 컴파일의 경우 `undefined`입니다.
+- `defaultLoaders` : `Object` - Next.js 내부에서 사용되는 기본 로더
+  - `babel` : `Object` - 기본 `babel-loader` 구성
+
+`defaultLoaders.babel` 사용법 예시 :
+
+```js
+// babel-loader에 의존하는 로더를 추가하는 구성 예제
+// @next/mdx 플러그인 소스로부터 발췌한 소스입니다.
+// https://github.com/vercel/next.js/tree/canary/packages/next-mdx
+module.exports = {
+  webpack: (config, options) => {
+    config.module.rules.push({
+      test: /\.mdx/,
+      use: [
+        options.defaultLoaders.babel,
+        {
+          loader: "@mdx-js/loader",
+          options: pluginOptions.options,
+        },
+      ],
+    });
+
+    return config;
+  },
+};
+```
+
+<br><hr><br>
+
+## `nextRuntime`
+
+주목할 점은 `nextRuntime`이 `"edge"` 또는 `"nodejs"`일 때 `isServer`가 `true`인 것입니다. nextRuntime `"edge"`는 현재 edge 런타임 내 미들웨어와 서버 컴포넌트 전용입니다.

--- a/nextjsdocs/BuildingYourApplication/Upgrading/App_Router_Migration.md
+++ b/nextjsdocs/BuildingYourApplication/Upgrading/App_Router_Migration.md
@@ -1,6 +1,6 @@
 # **앱 라우터(App Router) 점진적 적용 가이드**
 
-공식 문서 : [https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration](../Upgrading.md/app-router-migration)
+공식 문서 : [https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration](https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration)
 
 > ※ 링크가 추가되어 있으나 해당되는 내용이 없는 경우가 있습니다. 이러한 경우에는 하이퍼링크 텍스트의 뒷부분에 '※' 표시를 달아두겠습니다. - 번역자 드림
 


### PR DESCRIPTION
APIReference/next.config.jsOptions 경로의 rewrites 등 5개 항목 번역 완료했습니다!

2023.06.08. 4개 항목 추가하였습니다. (_이탤릭체_)

force push한 흔적은 제가 rebase를 잘못 사용하여 이미 PR이 완료된 커밋 내역이 제가 작업한 커밋 내역으로 반영되어 다시 PR되는 문제가 있어서 되돌린 흔적입니다. 

## _reactStrictMode_
  - 번역 완료했습니다.
  
## _redirects_
  - 번역 완료했습니다.
 
## rewrites
  - 번역 완료했습니다.
  - rewrited로 되어 있던 파일명을 수정하고 README에 반영하였습니다.
  - 기존 번역 문서에서 'rewrited.md'로 연결된 링크 없음 확인했습니다.

## RuntimeConfig
  - 번역 완료했습니다.
  - serverRuntimeConfig_and_publicRuntimeConfig로 되어 있던 기존 파일명을 수정하고 README에 반영하였습니다.
  - 기존 번역 문서에서 연결된 링크 없음 확인했습니다. (pages 문서로 연결된 링크만 하나 확인)
  
## serverComponentsExternalPackages
  - 번역 완료했습니다.
  
## trailingSlash
  - 번역 완료했습니다.
  
## transpilePackages
  - 번역 완료했습니다.
  
## _webpack_
  - 번역 완료했습니다.

## _webVitalsAttribution_
  - 번역 완료했습니다.